### PR TITLE
Propagate saved entries to redux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ npm-debug.log
 db.json
 client/build/*
 scrumdog.sqlite
+scrumdog.sqlite.*
 .DS_Store

--- a/client/src/css/style.scss
+++ b/client/src/css/style.scss
@@ -41,7 +41,6 @@ a {
   }
 
   .link-manage-users {
-    display: block;
     color: $midBlue;
     text-decoration: none;
     margin: 0 0 16px;
@@ -171,7 +170,6 @@ a {
 }
 
 #sidebar .links a {
-  display: block;
   color: $midBlue;
   text-decoration: none;
   &:hover {

--- a/client/src/js/reducers.js
+++ b/client/src/js/reducers.js
@@ -95,6 +95,25 @@ function activeStandup(state = defaultState.activeStandup, action) {
       });
     }
 
+    case 'RECEIVE_SAVE_ENTRY': {
+      const { data } = action;
+
+      // not this standup, ignore
+      if (data.StandupId !== state.id) {
+        return state;
+      }
+
+      return Object.assign({}, state, {
+        Entries: state.Entries.map((entry) => {
+          if (entry.id === data.id) {
+            return data;
+          }
+          return entry;
+        }),
+      });
+    }
+
+
     case 'RECEIVE_REMOVE_ENTRY': {
       // filter the removed Entry out of Entries[]
 

--- a/roadmap.md
+++ b/roadmap.md
@@ -6,11 +6,10 @@
 
 ## Bugs, fixes, refactor
 
-* 'Manage Users' button in standup view shouldn't be 100% width
+* Implement a uniform pattern for error handling (errors reducer and flash messages?)
+  * Currently no connectivity error handling in the UI
 * Saving a user doesn't update their details in an active standup (doens't propagate to Team Users maybe?)
 * Get everything linted
 * Refactor from actions.js and reducers.js to using ducks
-* Implement a uniform pattern for error handling (errors reducer and flash messages?)
 * Implement a clean fetching/loading state pattern
 * clean up the users reducer and state (think it's the last normalized reducer)
-

--- a/roadmap.md
+++ b/roadmap.md
@@ -6,6 +6,8 @@
 
 ## Bugs, fixes, refactor
 
+* 'Manage Users' button in standup view shouldn't be 100% width
+* Saving a user doesn't update their details in an active standup (doens't propagate to Team Users maybe?)
 * Get everything linted
 * Refactor from actions.js and reducers.js to using ducks
 * Implement a uniform pattern for error handling (errors reducer and flash messages?)


### PR DESCRIPTION
- Handles the RECEIVE_SAVE_ENTRY action so that saved entries are pushed into the redux store.
- Fix an issue with the Manage Users button width being too wide and accidentally clickable